### PR TITLE
Add ocaml compiler so Xen can be built with ocaml-implemented xenstore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,13 @@ RUN dnf install -y \
     \
     # For latest grcov/openssl build:
     perl-IPC-Cmd \
+    \
     # For building guest images in CI:
     e4fsprogs xfsprogs \
+    \
+    # For building Xen with ocaml-implemented xenstore
+    ocaml ocaml-compiler-libs ocaml-runtime ocaml-findlib \
+    \
     && dnf clean all && \
     rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Xen has an 'oxenstore' implemented in ocaml which is supposed to be superior  to the C-based daemon we've been using all this time.  This revision adds the necessary ocaml packages to enable building it.